### PR TITLE
Fix case mismatch between filenames in CMakeLists and actual files

### DIFF
--- a/Src/Vessel/Dragonfly/CMakeLists.txt
+++ b/Src/Vessel/Dragonfly/CMakeLists.txt
@@ -8,14 +8,14 @@ if(OPENGL_FOUND) # OpenGL is required for this target
 
 add_library(Dragonfly SHARED
 	Dragonfly.cpp
-	internal.cpp
+	Internal.cpp
 	instruments.cpp
-	matrix.cpp
+	Matrix.cpp
 	quaternion.cpp
 	vectors.cpp
-	hsystems.cpp
-	thermal.cpp
-	esystems.cpp
+	Hsystems.cpp
+	Thermal.cpp
+	Esystems.cpp
 )
 
 set_target_properties(Dragonfly

--- a/Src/Vessel/ShuttleA/ShuttleA_PL/CMakeLists.txt
+++ b/Src/Vessel/ShuttleA/ShuttleA_PL/CMakeLists.txt
@@ -8,7 +8,7 @@ set(TEXTURE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Textures)
 set(CONFIG_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Config)
 
 add_library(ShuttleA_PL SHARED
-	ShuttleA_PL.cpp
+	ShuttleA_pl.cpp
 )
 
 set_target_properties(ShuttleA_PL

--- a/Src/Vessel/Solarsail/CMakeLists.txt
+++ b/Src/Vessel/Solarsail/CMakeLists.txt
@@ -6,7 +6,7 @@ set(MESH_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Meshes)
 set(CONFIG_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Config)
 
 add_library(Solarsail SHARED
-	SolarSail.cpp
+	Solarsail.cpp
 	SailLua.cpp
 )
 


### PR DESCRIPTION
There are a few CMakeLists with filenames that don't exactly match the actual files due to case mismatch. On Windows, this doesn't cause any problems since the NTFS is case-insensitive by default, but there's no downside to using exact filenames anyway.