### PR TITLE
OrbiterSDK now respects ORBITER_MAKE_DOC CMake option

### DIFF
--- a/Orbitersdk/CMakeLists.txt
+++ b/Orbitersdk/CMakeLists.txt
@@ -2,7 +2,11 @@
 # Licensed under the MIT License
 
 add_subdirectory(samples)
-add_subdirectory(doc)
+
+if (ORBITER_MAKE_DOC)
+	add_subdirectory(doc)
+endif()
+
 if(Doxygen_FOUND)
 	add_subdirectory(doxygen)
 endif()


### PR DESCRIPTION
Required to compile orbiter without docToPdf