### PR TITLE
New Main Loop

### DIFF
--- a/Src/Orbiter/Timer.h
+++ b/Src/Orbiter/Timer.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <Windows.h>
+
+namespace TChapman500
+{
+	class Timer
+	{
+	public:
+		Timer()
+		{
+			LARGE_INTEGER frequency;
+			QueryPerformanceFrequency(&frequency);
+			Frequency = (double)frequency.QuadPart;
+			Difference.QuadPart = 0ULL;
+			QueryPerformanceCounter(&Start);
+			Current.QuadPart = Start.QuadPart;
+		}
+		
+		~Timer() {}
+		
+		double Lap()
+		{
+			QueryPerformanceCounter(&Current);
+			Difference.QuadPart = Current.QuadPart - Start.QuadPart;
+			Start.QuadPart = Current.QuadPart;
+			return (double)Difference.QuadPart / Frequency;
+		}
+		
+		double RunTime()
+		{
+			QueryPerformanceCounter(&Current);
+			Difference.QuadPart = Current.QuadPart - Start.QuadPart;
+			return (double)Difference.QuadPart / Frequency;
+		}
+
+	private:
+
+		double Frequency = 0.0;
+		LARGE_INTEGER Start;
+		LARGE_INTEGER Current;
+		LARGE_INTEGER Difference;
+	};
+}


### PR DESCRIPTION
Don't worry, I kept the old loop behind a `#define DO_OLD_MAIN_LOOP` preprocessor directive.  Other than making the old loop more readable for me, I left it completely untouched.  The new loop processes all of the messages at once, then user input, then ticks the simulation as many times as needed to keep the simulation running at a realtime pace.  At least, that's what's supposed to happen.