### PR TITLE
Adding 2-core parallel compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ on:
 jobs:
   build:
     name: Build with CMake
+    env:
+      CMAKE_BUILD_PARALLEL_LEVEL: 2
     strategy:
       fail-fast: false
       matrix:

--- a/Src/Plugin/ScriptMFD/CMakeLists.txt
+++ b/Src/Plugin/ScriptMFD/CMakeLists.txt
@@ -20,7 +20,8 @@ target_link_libraries(ScriptMFD
 
 add_dependencies(ScriptMFD
 	${OrbiterTgt}
-	Orbitersdk
+	Orbitersdk	
+	LuaInterpreter
 )
 
 set_target_properties(ScriptMFD


### PR DESCRIPTION
* x86 compilation time down by 40-50% 10m -> 5-6m
* x64 compilation time down by 10-50% - 6m -> 3-5m
GitHub agents performance seems to be a bit inconsistent, but the improvement is definitely visible