### PR TITLE
30 warning missing return values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,13 +87,13 @@ set(HTMLHELP_LIB_DIR ${HTMLHELP_DIR}/lib-${ARCH})
 set(HTMLHELP_LIB ${HTMLHELP_LIB_DIR}/Htmlhelp.lib)
 
 set(ORBITER_TOOL_MESHC "$<TARGET_FILE:meshc>")
-
+set(LUA_EXE ${LUA_DIR}/bin/lua.exe)
+set(ldoc ${LUA_EXE} ${LUA_DIR}/packages/LDoc/ldoc.lua)
 
 find_package(OpenGL QUIET)
 find_package(HTMLHelp)
 find_package(Doxygen)
 find_package(LATEX)		
-set(ldoc ${CMAKE_SOURCE_DIR}/Extern/Lua/bin/lua ${CMAKE_SOURCE_DIR}/Extern/Lua/packages/LDoc/ldoc.lua)
 
 # We don't query Qt with find_package because we need the 64-bit version here
 set(Qt5_x64_DIR

--- a/OVP/D3D7Client/CMakeLists.txt
+++ b/OVP/D3D7Client/CMakeLists.txt
@@ -63,6 +63,12 @@ target_link_libraries(D3D7Client
 	${DX7SDK_LIB_DIR}/ddraw.lib
 )
 
+set_target_properties(D3D7Client
+	PROPERTIES
+	COMPILE_DEFINITIONS "DIRECTINPUT_VERSION=0x0800"
+	FOLDER OVP
+)
+
 # Installation
 install(TARGETS
 	D3D7Client

--- a/Src/Vessel/DeltaGlider/AAPSubsys.cpp
+++ b/Src/Vessel/DeltaGlider/AAPSubsys.cpp
@@ -47,6 +47,7 @@ bool AAPSubsystem::clbkLoadPanel2D (int panelid, PANELHANDLE hPanel, DWORD viewW
 
 	int xofs = 90, yofs = 149;
 	DG()->RegisterPanelArea (hPanel, ELID_AAP, _R(xofs,yofs,xofs+65,yofs+124), PANEL_REDRAW_MOUSE, PANEL_MOUSE_LBDOWN | PANEL_MOUSE_LBPRESSED | PANEL_MOUSE_LBUP, 0, aap);
+	return true;
 }
 
 // --------------------------------------------------------------

--- a/Src/Vessel/DeltaGlider/DeltaGlider.cpp
+++ b/Src/Vessel/DeltaGlider/DeltaGlider.cpp
@@ -632,6 +632,7 @@ bool DeltaGlider::RedrawPanel_ScramFlow (SURFHANDLE surf)
 	}
 	if (redraw) {
 		oapiBltPanelAreaBackground (AID_SCRAMDISP2, surf);
+		return true;
 		//return RedrawPanel_IndicatorPair (surf, scflowidx, 66);
 	} else return false;
 }
@@ -673,6 +674,7 @@ bool DeltaGlider::RedrawPanel_MainFlow (SURFHANDLE surf)
 	}
 	if (redraw) {
 		oapiBltPanelAreaBackground (AID_MAINDISP1, surf);
+		return true;
 		//return RedrawPanel_IndicatorPair (surf, mainflowidx, 66);
 	} else return false;
 }
@@ -689,6 +691,7 @@ bool DeltaGlider::RedrawPanel_RetroFlow (SURFHANDLE surf)
 	}
 	if (redraw) {
 		oapiBltPanelAreaBackground (AID_MAINDISP2, surf);
+		return true;
 		//return RedrawPanel_IndicatorPair (surf, retroflowidx, 66);
 	} else return false;
 }

--- a/Src/Vessel/DeltaGlider/DeltaGlider.h
+++ b/Src/Vessel/DeltaGlider/DeltaGlider.h
@@ -343,9 +343,9 @@ typedef struct {
 
 // Panel area identifiers:
 // Panel 0
-#define AID_MAINDISP1           32
-#define AID_MAINDISP2           33
-#define AID_MAINDISP3           34
+#define AID_MAINDISP1           32 // obsolete
+#define AID_MAINDISP2           33 // obsolete
+#define AID_MAINDISP3           34 // obsolete
 #define AID_SCRAMDISP2          36
 
 // Panel 1


### PR DESCRIPTION
closes #30 
fixes warning temporarily. But still requires proper code cleanup to remove obsolete DG panel code.